### PR TITLE
always upload to codecov

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -44,7 +44,7 @@ jobs:
           uv run pytest --cov eor_limits --cov-report xml:coverage.xml
 
       - uses: codecov/codecov-action@v5
-        if: matrix.os == 'ubuntu-latest' && success()
+        if: success()
         with:
           files: ./coverage.xml #optional
           verbose: true

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          uv run pytest --cov eor_limits --cov-report xml:coverage.xml
+          uv run --no-sync pytest --cov eor_limits --cov-report xml:coverage.xml
 
       - uses: codecov/codecov-action@v5
         if: success()

--- a/uv.lock
+++ b/uv.lock
@@ -585,6 +585,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cattrs" },
     { name = "cyclopts" },
+    { name = "h5py" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
@@ -614,6 +615,7 @@ docs = [
 requires-dist = [
     { name = "cattrs", specifier = ">=25.3.0" },
     { name = "cyclopts", specifier = ">=4.5.1" },
+    { name = "h5py", specifier = ">=3.15.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pandas", specifier = ">=3.0.0" },


### PR DESCRIPTION
Update test-suite action to always upload to codecov regardless of the os. This will also test if I got the codecov token set up properly.

I also set `no-sync` when calling `uv run` for the tests to preserve the sync choices from the prior step. That caused the `--frozen` tests to fail, so I updated the lock file as well.